### PR TITLE
Fix gpg init failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /build/
 COPY build.sh VERSION /build/
 RUN bash build.sh
 
-FROM ubuntu:latest
+FROM ubuntu:bionic
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp


### PR DESCRIPTION
Change docker base image from `ubuntu:latest` to `ubuntu:bionic` to fix the gpg initalization failure (#7).