### PR TITLE
Bump Go to 1.15 for build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS build
+FROM golang:1.15 AS build
 
 # Install dependencies
 RUN apt-get update && apt-get install -y libsecret-1-dev


### PR DESCRIPTION
Golang 1.15 is needed to build version 1.8.5 correctly.