### PR TITLE
run as non-root in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tag | description
 To initialize and add account to the bridge, run the following command.
 
 ```
-docker run --rm -it -v protonmail:/root shenxn/protonmail-bridge init
+docker run --rm -it -v protonmail:/home/protonmail shenxn/protonmail-bridge init
 ```
 
 Wait for the bridge to startup, use `login` command and follow the instructions to add your account into the bridge. Then use `info` to see the configuration information (username and password). After that, use `exit` to exit the bridge. You may need `CTRL+C` to exit the docker entirely.
@@ -48,7 +48,7 @@ Wait for the bridge to startup, use `login` command and follow the instructions 
 To run the container, use the following command.
 
 ```
-docker run -d --name=protonmail-bridge -v protonmail:/root -p 1025:25/tcp -p 1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
+docker run -d --name=protonmail-bridge -v protonmail:/home/protonmail -p 1025:25/tcp -p 1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
 ```
 
 ## Kubernetes
@@ -62,7 +62,7 @@ If you don't want to use Helm, you can also reference to the guide ([#6](https:/
 Please be aware that running the command above will expose your bridge to the network. Remember to use firewall if you are going to run this in an untrusted network or on a machine that has public IP address. You can also use the following command to publish the port to only localhost, which is the same behavior as the official bridge package.
 
 ```
-docker run -d --name=protonmail-bridge -v protonmail:/root -p 127.0.0.1:1025:25/tcp -p 127.0.0.1:1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
+docker run -d --name=protonmail-bridge -v protonmail:/home/protonmail -p 127.0.0.1:1025:25/tcp -p 127.0.0.1:1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
 ```
 
 Besides, you can publish only port 25 (SMTP) if you don't need to receive any email (e.g. as a email notification service).

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,4 +25,11 @@ COPY gpgparams entrypoint.sh /protonmail/
 # Copy protonmail
 COPY --from=build /build/proton-bridge/proton-bridge /protonmail/
 
+# Add a user 'protonmail' with UID 8535
+RUN useradd -u 8535 -d /home/protonmail protonmail \
+    && mkdir -p /home/protonmail \
+    && chown protonmail: /home/protonmail
+# change to non-privileged user for extra security
+USER protonmail
+
 ENTRYPOINT ["bash", "/protonmail/entrypoint.sh"]

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+id
+# Go to current user's homedir
+cd
+echo $PWD
+
 # Initialize
 if [[ $1 == init ]]; then
 


### PR DESCRIPTION
As good security practice (e.g. see https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html)

Note that existing users will likely have to re-create the docker volume and re-run the initialization to ensure the files have the right perms.

Alternatively, a command like:
`sudo chown -R 8535:8535 /var/lib/docker/volumes/protonmail/_data/`
may also do the trick if your docker volumes are stored under /var/lib/docker/volumes.