### PR TITLE
Workaround to compile for 32bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Docker Hub: [https://hub.docker.com/r/shenxn/protonmail-bridge](https://hub.dock
 
 GitHub: [https://github.com/shenxn/protonmail-bridge-docker](https://github.com/shenxn/protonmail-bridge-docker)
 
-## ARMv7 Builds
-
-Currently there is a problem building the new parser targeting 32-bit architectures (i.e. `arm/v7`). The latest working build is `1.4.5-build`. Therefore, if you are using an `arm/v7` device like Raspberry Pi, do not upgrade to newer version. More information about the problem can be found [here](https://www.reddit.com/r/ProtonMail/comments/jvzm12/issue_building_bridge_150/). If you have any idea on how to fix this, a PR is welcome.
-
 ## ARM Support
 
 We now support ARM devices (`arm64` and `arm/v7`)! Use the images tagged with `build`. See next section for details.

--- a/build/build.sh
+++ b/build/build.sh
@@ -10,4 +10,13 @@ cd proton-bridge
 git checkout v$VERSION
 
 # Build
-make build-nogui
+if ! make build-nogui ; then
+	# If build fails it's probably because it is a 32bit
+	# system and there was a overflow error on the parser
+	# This is a workaround for this problem found at:
+	#   https://github.com/antlr/antlr4/issues/2433#issuecomment-774514106
+	find $(go env GOPATH)/pkg/mod/github.com/\!proton\!mail/go-rfc5322*/ -type f -exec sed -i.bak 's/(1<</(int64(1)<</g' {} +
+
+	# Try again after implementing the workaround
+	make build-nogui
+fi


### PR DESCRIPTION
This is a workaround based on [this comment](https://github.com/antlr/antlr4/issues/2433#issuecomment-774514106).
It is not a pretty solution but it worked well on my test file.

It runs once to compile, if make fails, then it apply the fix and try again, this is done so builds that don't need workaround don't use it and also because the workaround is done on top of downloaded files during the first compilation.

Version 1.4.5 is not accepted by Protonmail any more, so there is no current version that runs on a raspberry pi. This workaround should allow us to build recent versions.