### PR TITLE
Add riscv64 support to CI docker builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ on:
 env:
   DOCKER_REPO: shenxn/protonmail-bridge
   DOCKER_REPO_DEV: ghcr.io/shenxn/protonmail-bridge-dev
-  PLATFORMS: linux/amd64,linux/arm64/v8,linux/arm/v7
+  PLATFORMS: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/riscv64
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+# Ignoring IDE-specific files
+.idea/*
 .vscode

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We now support ARM devices (`arm64` and `arm/v7`)! Use the images tagged with `b
 
 There are two types of images.
  - `deb`: Images based on the official [.deb release](https://protonmail.com/bridge/install). It only supports the `amd64` architecture.
- - `build`: Images based on the [source code](https://github.com/ProtonMail/proton-bridge). It supports `amd64`, `arm64`, and `arm/v7`. Supporting to more architectures is possible. PRs are welcome.
+ - `build`: Images based on the [source code](https://github.com/ProtonMail/proton-bridge). It supports `amd64`, `arm64`, `arm/v7` and `riscv64`. Supporting to more architectures is possible. PRs are welcome.
 
 tag | description
  -- | --

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /build/
 COPY build.sh VERSION /build/
 RUN bash build.sh
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp


### PR DESCRIPTION
Hello @shenxn!

In the readme there was a note about being open for PRs for docker platform support.

I would love to see this project supporting riscv64.

RISC-V is an open standard instruction set architecture, which is under rapid development. Distributions including AOSP, Arch Linux, Debian, Gentoo Linux, Fedora, OpenEuler, etc are also actively doing porting work for this architecture.

As for the changes in the PR:

* Adjust GitHub CI to also build for riscv64 based on the existing QEMU/buildx setup
* Update base Ubuntu base for build from 18.04 LTS to 20.04 LTS as to support riscv64
* Minor: Exclude idea IDE files from git