### PR TITLE
Fix entrypoint so it works correctly on init

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -8,6 +8,9 @@ if [[ $1 == init ]]; then
     # Initialize pass
     gpg --generate-key --batch /protonmail/gpgparams
     pass init pass-key
+    
+    # Kill the other instance as only one can be running at a time
+    pkill protonmail-bridge
 
     # Login
     /protonmail/proton-bridge --cli $@


### PR DESCRIPTION
Ran into this issue when trying to use in kubernetes via k8s-at-home/protonmail-bridge. Took a bit of figuring out before I realized I had to manually kill the other instance. The only output from the failed load is a dbus issue, and an immediate exit.