### PR TITLE
Expose TCP:1025 and TCP:1143

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,6 +13,8 @@ LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp
 EXPOSE 143/tcp
+EXPOSE 1025/tcp
+EXPOSE 1143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \


### PR DESCRIPTION
Due to unraid limitations, if you set the network to br0 which bypasses the unraid reverse proxy, you cant change ports on the docker container.

https://www.reddit.com/r/unRAID/comments/i98wl2/br0_port_80/