### PR TITLE
Add a docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '2.1'
+
 services:
   protonmail-bridge:
     image: shenxn/protonmail-bridge
@@ -8,8 +10,9 @@ services:
     ports:
       - 1025:25/tcp
       - 1143:143/tcp
-    volumes:
-      - protonmail:/root
     restart: unless-stopped
     stdin_open: true 
     tty: true
+volumes:
+  protonmail:
+    name: protonmail

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  protonmail-bridge:
+    image: shenxn/protonmail-bridge
+    # build:
+    #  context: ./build
+    #  dockerfile: Dockerfile
+    container_name: pm_bridge
+    ports:
+      - 1025:25/tcp
+      - 1143:143/tcp
+    volumes:
+      - protonmail:/root
+    restart: unless-stopped
+    stdin_open: true 
+    tty: true


### PR DESCRIPTION
It's quite the norm to include a docker-compose file, generally in the README or the root for people to copy and modify. For example as https://github.com/wfg/docker-openvpn-client has done so.

If there are [Environmental variables](https://github.com/wfg/docker-openvpn-client#environment-variables), they should also be documented - in this case there isn't.