### PR TITLE
Update Ubuntu tag for deb to fix GLIBC dependency

### DIFF
--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp


### PR DESCRIPTION
GLIBC dependency issue highlighted in https://github.com/shenxn/protonmail-bridge-docker/issues/79 is caused by v3 of the bridge not supporting bionic. This PR simply updates the "deb" version to match the "build" version which is already on ubuntu:jammy.