### PR TITLE
Fix deb image

### DIFF
--- a/deb/install.sh
+++ b/deb/install.sh
@@ -15,7 +15,7 @@ apt-get install -y wget binutils xz-utils
 # Repack deb (remove unnecessary dependencies)
 mkdir deb
 cd deb
-wget -q https://protonmail.com/download/bridge/${DEB_FILE}
+wget -q https://proton.me/download/bridge/${DEB_FILE}
 ar x -v ${DEB_FILE}
 mkdir control
 tar zxvf control.tar.gz -C control


### PR DESCRIPTION
The image in `deb` directory doesn't build currently because the link to download has changed. This PR fixes the link.