### PR TITLE
The correct fix to the broken builds (switch to debian:sid-slim - it supports riscv64 now)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,14 @@
-# Use carlosedp/golang for riscv64 support
-FROM carlosedp/golang:1.18 AS build
+FROM debian:sid-slim AS build
 
 # Install dependencies
-RUN apt-get update && apt-get install -y git build-essential libsecret-1-dev
+RUN apt-get update && apt-get install -y git golang build-essential libsecret-1-dev
 
 # Build
 WORKDIR /build/
 COPY build.sh VERSION /build/
 RUN bash build.sh
 
-FROM ubuntu:jammy
+FROM debian:sid-slim
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM debian:sid-slim
 LABEL maintainer="Xiaonan Shen <s@sxn.dev>"
 
 EXPOSE 25/tcp


### PR DESCRIPTION
tested locally, works fine.
debian has supported riscv64 in the sid image for some time.

this is the same thing the carlosedp/golang image did.

this also fixes the bug with the wrong glibc version, as the build container now uses the same glibc version as the final container.