### PR TITLE
Update golang toolchain to resolve build error

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Use carlosedp/golang for riscv64 support
-FROM carlosedp/golang:1.18 AS build
+FROM golang:1.21 AS build
 
 # Install dependencies
 RUN apt-get update && apt-get install -y git build-essential libsecret-1-dev


### PR DESCRIPTION
- Error "/build/proton-bridge/go.mod:5: unknown directive: toolchain" seems to be caused by outdated toolchain.
- Bumped toolchain to match what's in go.mod.