### PR TITLE
Enable Secure GPG

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ tag | description
 To initialize and add account to the bridge, run the following command.
 
 ```
-docker run --rm -it -v protonmail:/root shenxn/protonmail-bridge init
+docker run --rm -it -e KEYRING_PASSPHRASE='<your_passphrase>' -v protonmail:/root shenxn/protonmail-bridge init
 ```
 
-If you want to use Docker Compose instead, you can create a copy of the provided example [docker-compose.yml](docker-compose.yml) file, modify it to suit your needs, and then run the following command:
+If you want to use Docker Compose instead, you can create a copy of the provided example [docker-compose.yml](docker-compose.yml) file, modify it to suit your needs (making sure KEYRING_PASSPHRASE matches what was used during intitialization), and then run the following command:
 
 ```
 docker compose run protonmail-bridge init
@@ -50,7 +50,7 @@ Wait for the bridge to startup, then you will see a prompt appear for [Proton Ma
 To run the container, use the following command.
 
 ```
-docker run -d --name=protonmail-bridge -v protonmail:/root -p 1025:25/tcp -p 1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
+docker run -d --name=protonmail-bridge -e KEYRING_PASSPHRASE='<your_passphrase>' -v protonmail:/root -p 1025:25/tcp -p 1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
 ```
 
 Or, if using Docker Compose, use the following command.
@@ -70,7 +70,7 @@ If you don't want to use Helm, you can also reference to the guide ([#6](https:/
 Please be aware that running the command above will expose your bridge to the network. Remember to use firewall if you are going to run this in an untrusted network or on a machine that has public IP address. You can also use the following command to publish the port to only localhost, which is the same behavior as the official bridge package.
 
 ```
-docker run -d --name=protonmail-bridge -v protonmail:/root -p 127.0.0.1:1025:25/tcp -p 127.0.0.1:1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
+docker run -d --name=protonmail-bridge -e KEYRING_PASSPHRASE='<your_passphrase>' -v protonmail:/root -p 127.0.0.1:1025:25/tcp -p 127.0.0.1:1143:143/tcp --restart=unless-stopped shenxn/protonmail-bridge
 ```
 
 Besides, you can publish only port 25 (SMTP) if you don't need to receive any email (e.g. as a email notification service).

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,14 +1,37 @@
 #!/bin/bash
 
-set -ex
+set -e
+
+if [ -z "$KEYRING_PASSPHRASE" ]; then
+    echo "KEYRING_PASSPHRASE cannot be empty"
+    exit 1
+fi
+
+gpg_present_phrase () {
+    /usr/lib/gnupg2/gpg-preset-passphrase -P "$KEYRING_PASSPHRASE" \
+      -c "$(basename "$HOME"/.gnupg/private-keys-v1.d/*.key .key)"
+}
+
+# Start gpg-agent to force allow presetting passphrase
+gpg-agent --homedir "$HOME"/.gnupg --daemon --allow-preset-passphrase
 
 # Initialize
 if [[ $1 == init ]]; then
 
-    # Initialize pass
-    gpg --generate-key --batch /protonmail/gpgparams
-    pass init pass-key
-    
+    # Initialize GPG if no private key
+    # While -f can't handle globs, only one key can be generated
+    if [ ! -f "$HOME"/.gnupg/private-keys-v1.d/*.key ]; then
+      gpg --generate-key --passphrase "$KEYRING_PASSPHRASE" --pinentry-mode loopback \
+        --batch /protonmail/gpgparams
+    fi
+
+    # Initialize pass if no password-store
+    if [ ! -d "$HOME"/.password-store ]; then
+      pass init pass-key
+    fi
+
+    gpg_present_phrase
+
     # Kill the other instance as only one can be running at a time.
     # This allows users to run entrypoint init inside a running conainter
     # which is useful in a k8s environment.
@@ -16,9 +39,11 @@ if [[ $1 == init ]]; then
     pkill protonmail-bridge || true
 
     # Login
-    /protonmail/proton-bridge --cli $@
+    /protonmail/proton-bridge --cli
 
 else
+    # Load passphrase into gpg-agent
+    gpg_present_phrase
 
     # socat will make the conn appear to come from 127.0.0.1
     # ProtonMail Bridge currently expects that.
@@ -30,6 +55,6 @@ else
     # Fake a terminal, so it does not quit because of EOF...
     rm -f faketty
     mkfifo faketty
-    cat faketty | /protonmail/proton-bridge --cli $@
+    cat faketty | /protonmail/proton-bridge --cli
 
 fi

--- a/build/gpgparams
+++ b/build/gpgparams
@@ -1,7 +1,6 @@
-%no-protection
 %echo Generating a basic OpenPGP key
 Key-Type: RSA
-Key-Length: 2048
+Key-Length: 4096
 Name-Real: pass-key
 Expire-Date: 0
 %commit

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -25,4 +25,4 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 ca-certificates procps \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["bash", "/protonmail/entrypoint.sh"]
+ENTRYPOINT ["bash", "/protonmail/entrypoint.sh"]

--- a/deb/gpgparams
+++ b/deb/gpgparams
@@ -1,7 +1,6 @@
-%no-protection
 %echo Generating a basic OpenPGP key
 Key-Type: RSA
-Key-Length: 2048
+Key-Length: 4096
 Name-Real: pass-key
 Expire-Date: 0
 %commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2.1'
 services:
   protonmail-bridge:
     image: shenxn/protonmail-bridge
+    environment:
+      - KEYRING_PASSPHRASE=
     ports:
       - 1025:25/tcp
       - 1143:143/tcp


### PR DESCRIPTION
Enables secure GPG via a new KEYRING_PASSPHRASE variable. This variable is used as the passphrase for generating gpg key and when reading gpg files. This prevents secrets from being saved in docker volumes without protection.

- enable gpg protection
- remove set -x to prevent logging password
- add checks to prevent re-initing pass and gpg
- present passphrase unlock via docker env variable
  - Note: gpg-agent will not expire gpg-present-passphrases
- fix deb CMD to ENTRYPOINT
