### PR TITLE
Run the bridge inside tmux to enable easy user interaction

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ EXPOSE 143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates \
+    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates procps tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:sid-slim AS build
 ARG version
 
 # Install dependencies
-RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev
+RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev libcbor-dev
 
 # Build
 ADD https://github.com/ProtonMail/proton-bridge.git#${version} /build/
@@ -19,7 +19,7 @@ EXPOSE 143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates procps tmux \
+    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates libfido2-1 procps tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -16,7 +16,11 @@ if [[ $1 == init ]]; then
     pkill protonmail-bridge || true
 
     # Login
-    /protonmail/proton-bridge --cli $@
+    tmux new-session -d -s bridge-init "/protonmail/proton-bridge --cli $@"
+    echo "ProtonMail Bridge init running inside tmux session 'bridge-init'"
+    echo "Attach with: docker exec -it <container> tmux attach -t bridge-init"
+
+    sleep infinity
 
 else
 
@@ -30,6 +34,11 @@ else
     # Fake a terminal, so it does not quit because of EOF...
     rm -f faketty
     mkfifo faketty
-    cat faketty | /protonmail/proton-bridge --cli $@
+
+    tmux new-session -d -s bridge "cat faketty | /protonmail/proton-bridge --cli $@"
+    echo "ProtonMail Bridge running inside tmux session 'bridge'"
+    echo "Attach with: docker exec -it <container> tmux attach -t bridge"
+
+    sleep infinity
 
 fi

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -30,12 +30,7 @@ else
     socat TCP-LISTEN:25,fork TCP:127.0.0.1:1025 &
     socat TCP-LISTEN:143,fork TCP:127.0.0.1:1143 &
 
-    # Start protonmail
-    # Fake a terminal, so it does not quit because of EOF...
-    rm -f faketty
-    mkfifo faketty
-
-    tmux new-session -d -s bridge "cat faketty | /protonmail/proton-bridge --cli $@"
+    tmux new-session -d -s bridge "/protonmail/proton-bridge --cli $@"
     echo "ProtonMail Bridge running inside tmux session 'bridge'"
     echo "Attach with: docker exec -it <container> tmux attach -t bridge"
 


### PR DESCRIPTION
This pull request introduces a minor change that enables the Proton Mail Bridge CLI to run in a tmux session.
This allows for user interaction without having to kill and restart the bridge.

You can simply attach by running:
`docker exec -it <container> tmux attach -t bridge`

I tried to keep the changes to a minimum. There are certainly more clever, Docker-native ways of accomplishing the same thing.