### PR TITLE
Add libfido2 dependency for Bridge v3.22.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:sid-slim AS build
 ARG version
 
 # Install dependencies
-RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev
+RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev libcbor-dev
 
 # Build
 ADD https://github.com/ProtonMail/proton-bridge.git#${version} /build/
@@ -19,7 +19,7 @@ EXPOSE 143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates \
+    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 libfido2-1 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -22,7 +22,7 @@ COPY gpgparams entrypoint.sh PACKAGE /protonmail/
 COPY --from=build /protonmail.deb /tmp/protonmail.deb
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 ca-certificates procps \
+    && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 libfido2-1 ca-certificates procps \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["bash", "/protonmail/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Add `libfido2-dev` and `libcbor-dev` to the build stage for FIDO2/WebAuthn compilation support
- Add `libfido2-1` to the runtime stage in both `build/Dockerfile` and `deb/Dockerfile`
- Required by Bridge v3.22.0 which added FIDO2/WebAuthn support

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)