### PR TITLE
Resolve linking error libfido2.so.1

### DIFF
--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -22,7 +22,8 @@ COPY gpgparams entrypoint.sh PACKAGE /protonmail/
 COPY --from=build /protonmail.deb /tmp/protonmail.deb
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 ca-certificates procps \
+    && apt-get install -y --no-install-recommends /tmp/protonmail.deb \
+       socat pass libsecret-1-0 ca-certificates procps libfido2-1 \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["bash", "/protonmail/entrypoint.sh"]


### PR DESCRIPTION
Resolved #135
```
+ pass init pass-key
...
+ protonmail-bridge --cli
/root/.local/share/protonmail/bridge-v3/updates/3.22.0/bridge: error while loading shared libraries: libfido2.so.1: cannot open shared object file: No such file or directory

Failed to launch                              error="exit status 127" exe_path=/root/.local/share/protonmail/bridge-v3/updates/3.22.0/bridge exe_to_launch=bridge launcher_path=/root/.local/share/protonmail/bridge-v3/updates/3.22.0/proton-bridge launcher_version=3.22.0

Failed to launch                              error="exit status 1" exe_path=/root/.local/share/protonmail/bridge-v3/updates/3.22.0/proton-bridge launcher_path=/usr/lib/protonmail/bridge/proton-bridge launcher_version=3.19.0

```
- https://developers.yubico.com/libfido2/