### PR TITLE
Added missing build and runtime deps for latest build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:sid-slim AS build
 ARG version
 
 # Install dependencies
-RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev
+RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev pkg-config libcbor-dev
 
 # Build
 ADD https://github.com/ProtonMail/proton-bridge.git#${version} /build/
@@ -19,7 +19,7 @@ EXPOSE 143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates \
+    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates libcbor0.10 libfido2-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts


### PR DESCRIPTION
Seems to build and run the latest version of the bridge some new build and runtime deps are required.

I've tested this and it appears to fix it.