### PR TITLE
fix: add libfido2-1 and libsecret-1-0 to runtime deps

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,7 +19,7 @@ EXPOSE 143/tcp
 
 # Install dependencies and protonmail bridge
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates \
+    && apt-get install -y --no-install-recommends socat pass libsecret-1-0 ca-certificates libfido2-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy bash scripts

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:sid-slim AS build
 ARG version
 
 # Install dependencies
-RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev
+RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev libcbor-dev
 
 # Build
 ADD https://github.com/ProtonMail/proton-bridge.git#${version} /build/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:sid-slim AS build
 ARG version
 
 # Install dependencies
-RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev
+RUN apt-get update && apt-get install -y golang build-essential libsecret-1-dev libfido2-dev
 
 # Build
 ADD https://github.com/ProtonMail/proton-bridge.git#${version} /build/

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -22,7 +22,7 @@ COPY gpgparams entrypoint.sh PACKAGE /protonmail/
 COPY --from=build /protonmail.deb /tmp/protonmail.deb
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 ca-certificates procps \
+    && apt-get install -y --no-install-recommends /tmp/protonmail.deb socat pass libsecret-1-0 ca-certificates procps libfido2-1 \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["bash", "/protonmail/entrypoint.sh"]


### PR DESCRIPTION
## Problem

Since Proton Bridge 3.22, `libfido2-1` is a required runtime dependency that is no longer bundled with the upstream binary. Containers based on this image crash at startup with a missing shared library error (`libfido2.so.1`).

## Fix

Add `libfido2-1` to the `apt-get install` line in the runtime stage of both `build/Dockerfile` and `deb/Dockerfile`. `libsecret-1-0` and `ca-certificates` were already present. `--no-install-recommends` and `rm -rf /var/lib/apt/lists/*` are preserved.

## References

Refs #135, #141, #147

## Tested

Built and pushed a patched image for `linux/amd64` under my Docker Hub namespace (`smaier/protonmail-bridge`) for verification.